### PR TITLE
feat: Add docker-compose.yml for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-# Docker Compose file
-docker-compose.yml
+# Directory for local projects to be analyzed by the agent
 
 # Directory for local projects to be analyzed by the agent
 /projects/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  debugagent:
+    build:
+      context: .
+      dockerfile: debugagent/Dockerfile
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./debugagent/config.docker.yaml:/app/config.yaml
+    depends_on:
+      - ollama
+
+  frontend:
+    image: node:18
+    working_dir: /app/frontend
+    command: npm start
+    volumes:
+      - ./frontend:/app/frontend
+    ports:
+      - "3000:3000"
+
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders project analysis heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  const linkElement = screen.getByText(/Project Analysis/i);
   expect(linkElement).toBeInTheDocument();
 });


### PR DESCRIPTION
This commit adds a docker-compose.yml file to the root directory to orchestrate the `debugagent`, `frontend`, and `ollama` services for local development.

The `debugagent` service is built from the existing Dockerfile. The `frontend` service is configured to run in development mode with hot-reloading. The `ollama` service is added as a dependency for the `debugagent`.

This commit also includes two related changes:
- The `.gitignore` file was modified to allow the `docker-compose.yml` file to be checked into version control.
- A failing test in the frontend application was fixed to ensure the test suite passes.